### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who 
+contribute through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or
+imagery, derogatory comments or personal attacks, trolling, public or private harassment,
+insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this 
+Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed 
+from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
+opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the Contributor Covenant 
+(http://contributor-covenant.org), version 1.0.0, available at 
+http://contributor-covenant.org/version/1/0/0/

--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ a repository for slides, code, and other materials for the Tampa R Users Group
 <img src="https://www.r-consortium.org/wp-content/uploads/sites/13/2016/09/RConsortium_Horizontal_Pantone.png" width="200px">
 </a>
 
-Please note that we follow the [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
-By participating in the Tampa R Users Group you agree to abide by its terms.
+<br>
+Please note that we follow the [Contributor Code of Conduct](CODE_OF_CONDUCT.md) and the [R Consortium Community Code of Conduct](https://wiki.r-consortium.org/view/R_Consortium_and_the_R_Community_Code_of_Conduct).
+By participating in the Tampa R Users Group you agree to abide by their terms.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,6 @@ a repository for slides, code, and other materials for the Tampa R Users Group
 <a href="https://www.r-consortium.org/">
 <img src="https://www.r-consortium.org/wp-content/uploads/sites/13/2016/09/RConsortium_Horizontal_Pantone.png" width="200px">
 </a>
+
+Please note that we follow the [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
+By participating in the Tampa R Users Group you agree to abide by its terms.


### PR DESCRIPTION
This PR adds a code of conduct for the Tampa R Users Group on GitHub. The code of conduct is sourced from https://www.contributor-covenant.org/ via

```r
usethis::use_code_of_conduct()
```

and is commonly used in many R packages, such as [dplyr](https://github.com/tidyverse/dplyr).